### PR TITLE
Add media & migrations to .gitignore; Fix upload js bug (now it can cont...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ develop-eggs
 .installed.cfg
 pip-log.txt
 .DS_Store
+demo/migrations
+media

--- a/templates/chunked_upload_demo.html
+++ b/templates/chunked_upload_demo.html
@@ -57,7 +57,14 @@
       maxChunkSize: 100000, // Chunks of 100 kB
       formData: form_data,
       add: function(e, data) { // Called before starting upload
-        $("#mesages").empty();
+        $("#messages").empty();
+        // delete uploaded file message
+        for (var i = 0; i < form_data.length; ++i)
+          if ("name" in form_data[i]&& form_data[i]["name"] === "csrfmiddlewaretoken"){
+            form_data.splice(i+1, form_data.length-i-0);
+            form_data.splice(0, i);
+            break;
+          }
         calculate_md5(data.files[0], 100000);  // Again, chunks of 100 kB
         data.submit();
       },


### PR DESCRIPTION
1. After synchronizing database with South, a folder named _migrations_ is generated; after uploading files, a folder named _demo/media_ is generated.
2. Fix a typo: _mesages_
3. form_data need to be updated. If form_data is not updated when you upload the second file, it will cause a _Upload has already been marked as "complete"_ error.(because the previous file's upload_id is not removed.)
